### PR TITLE
Adds "saveAllBeforeRun" setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It won't work with standalone `.ex{s}` files.
 This extension contributes the following settings:
 
 - `exunit.clearBetweenRuns`: Specify whether the terminal should be cleared between test runs
+- `exunit.saveAllBeforeRun`: Specify whether to save all files before running tests
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
           "type": "boolean",
           "default": true,
           "description": "Specifies whether to clear the terminal between test runs"
+        },
+        "exunit.saveAllBeforeRun": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to save all files before running tests"
         }
       }
     }

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -71,6 +71,8 @@ function run(directory: string, command: string): void {
   const terminal = getTerminal(directory);
   if (getConfigValue("clearBetweenRuns")) terminal.sendText("tput reset");
 
+  if (getConfigValue("saveAllBeforeRun")) workspace.saveAll(false);
+
   terminal.sendText(command);
   terminal.show(true);
 }


### PR DESCRIPTION
Saves all files (except untitled files) before running any test command.
Useful for people who don't have auto-save enabled.